### PR TITLE
Add support for non-NVIDIA GPU's

### DIFF
--- a/build_script.bat
+++ b/build_script.bat
@@ -37,16 +37,7 @@ REM Upgrade pip
 python -m pip install --upgrade pip
 
 REM Install required packages
-set "packages=flask flask-cors psutil GPUtil pywin32 pyinstaller setuptools"
-
-for %%p in (%packages%) do (
-    echo Installing %%p...
-    python -m pip install %%p
-    if errorlevel 1 (
-        echo Failed to install %%p.
-        set "failed=1"
-    )
-)
+pip install -r requirements.txt
 
 if defined failed (
     echo.

--- a/performance_monitor_service.py
+++ b/performance_monitor_service.py
@@ -36,7 +36,7 @@ try:
 
     def get_gpu_vram():
         # Choose the GPU with the highest total VRAM, and return that GPU's memory usage (same idea as above)
-        return (u/t for (u,t) in max(((x.memoryUsed, x.memoryTotal) for x in GPUtil.getGPUs()), key=lambda x: x.memoryTotal) if t>0).next()
+        return (u/t for (u,t) in max(((x.memoryUsed, x.memoryTotal) for x in GPUtil.getGPUs()), key=lambda x: x[1]) if t>0).next()
 
 except ImportError:
     if os.name == "nt":

--- a/performance_monitor_service.py
+++ b/performance_monitor_service.py
@@ -24,28 +24,69 @@ from flask_cors import CORS
 import psutil
 
 # Optionally import GPUtil
+# Try NVIDIA-specific methods
 try:
     import GPUtil
-    GPU_AVAILABLE = True
+
+    device = GPUtil.getGPUs()[0]
+
+    def get_gpu_util():
+        return device.load
+
+    def get_gpu_vram():
+        return device.memoryUsed / device.memoryTotal
+
 except ImportError:
-    GPU_AVAILABLE = False
+    from subprocess import run
+
+    def get_gpu_util():
+        p = run(
+            [
+                "powershell",
+                "-Command",
+                '(((Get-Counter "\\GPU Engine(*)\\Utilization Percentage").CounterSamples | Where-Object CookedValue).CookedValue | Measure-Object -Sum | Select-Object -ExpandProperty Sum)',
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return (
+            float(p.stdout.rstrip().replace(",", ".") or "0")
+            if p.returncode == 0
+            else 0
+        )
+
+    def get_gpu_vram():
+        p = run(
+            [
+                "powershell",
+                "-Command",
+                '(((Get-Counter "\\GPU Adapter Memory(*)\\Dedicated Usage").CounterSamples | Where-Object CookedValue).CookedValue | Measure-Object -Sum | Select-Object -ExpandProperty Sum)',
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return (
+            float(p.stdout.rstrip().replace(",", ".") or "0")
+            if p.returncode == 0
+            else 0
+        )
+
 
 # Logging configuration
-LOG_DIR = Path(os.path.expandvars(r'%PROGRAMDATA%\PerformanceMonitor'))
+LOG_DIR = Path(os.path.expandvars(r"%PROGRAMDATA%\PerformanceMonitor"))
 LOG_DIR.mkdir(exist_ok=True)
-LOG_FILE = LOG_DIR / 'performance_monitor.log'
+LOG_FILE = LOG_DIR / "performance_monitor.log"
 
-logger = logging.getLogger('PerformanceMonitor')
+logger = logging.getLogger("PerformanceMonitor")
 logger.setLevel(logging.INFO)
 
 # console log and log file handler (INFO and above)
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler(LOG_FILE, encoding='utf-8'),
-        logging.StreamHandler()
-    ]
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.FileHandler(LOG_FILE, encoding="utf-8"), logging.StreamHandler()],
 )
 
 
@@ -53,7 +94,7 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
     _svc_name_ = "PerformanceMonitor"
     _svc_display_name_ = "Performance Monitor Service"
     _svc_description_ = "System performance monitoring service for Wallpaper Engine"
-    
+
     def __init__(self, args):
         win32serviceutil.ServiceFramework.__init__(self, args)
         self.hWaitStop = win32event.CreateEvent(None, 0, 0, None)
@@ -62,26 +103,28 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
         self.monitor_thread = None
         self.running = False
         self.performance_data = {}
-        self.data_file = LOG_DIR / 'performance.json'
+        self.data_file = LOG_DIR / "performance.json"
         self.port = self.load_port_config()
-        
+
         logger.warning(f"Performance Monitor Service initialized (Port: {self.port})")
-    
+
     def load_port_config(self):
         """Load port configuration"""
         try:
-            if getattr(sys, 'frozen', False):
+            if getattr(sys, "frozen", False):
                 config_dir = Path(sys.executable).parent
             else:
                 config_dir = Path(__file__).parent
-            
-            config_file = config_dir / 'config.json'
-            
+
+            config_file = config_dir / "config.json"
+
             if config_file.exists():
-                with open(config_file, 'r', encoding='utf-8') as f:
+                with open(config_file, "r", encoding="utf-8") as f:
                     config = json.load(f)
-                    port = config.get('port', 5000)
-                    logger.warning(f"Port configuration loaded from {config_file}: {port}")
+                    port = config.get("port", 5000)
+                    logger.warning(
+                        f"Port configuration loaded from {config_file}: {port}"
+                    )
                     return port
             else:
                 return 5000
@@ -94,11 +137,11 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
         self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
         win32event.SetEvent(self.hWaitStop)
         self.running = False
-        
+
         if self.flask_thread and self.flask_thread.is_alive():
             logger.info("Stopping Flask application...")
             # Note: Graceful shutdown of Flask is complex; relies on process exit
-        
+
         logger.info("Service stopped")
 
     def SvcDoRun(self):
@@ -106,9 +149,9 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
         servicemanager.LogMsg(
             servicemanager.EVENTLOG_INFORMATION_TYPE,
             servicemanager.PYS_SERVICE_STARTED,
-            (self._svc_name_, '')
+            (self._svc_name_, ""),
         )
-        
+
         try:
             self.running = True
             self.main()
@@ -118,94 +161,94 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
             servicemanager.LogMsg(
                 servicemanager.EVENTLOG_ERROR_TYPE,
                 servicemanager.PYS_SERVICE_STOPPED,
-                (self._svc_name_, str(e))
+                (self._svc_name_, str(e)),
             )
 
     def create_flask_app(self):
         """Create Flask application"""
         app = Flask(__name__)
         CORS(app, origins="*")
-        
+
         app.logger.setLevel(logging.WARNING)
-        logging.getLogger('werkzeug').setLevel(logging.WARNING)
-        
-        @app.route('/performance', methods=['GET'])
+        logging.getLogger("werkzeug").setLevel(logging.WARNING)
+
+        @app.route("/performance", methods=["GET"])
         def get_performance():
             try:
                 if self.data_file.exists():
-                    with open(self.data_file, 'r', encoding='utf-8') as f:
+                    with open(self.data_file, "r", encoding="utf-8") as f:
                         data = json.load(f)
                 else:
                     data = self.get_default_data()
                 return jsonify(data)
             except Exception as e:
                 logger.error(f"Error serving performance data: {e}")
-                return jsonify({'error': str(e)}), 500
-        
-        @app.route('/status', methods=['GET'])
+                return jsonify({"error": str(e)}), 500
+
+        @app.route("/status", methods=["GET"])
         def get_status():
             """Return service status"""
-            return jsonify({
-                'status': 'running',
-                'service': self._svc_display_name_,
-                'port': self.port,
-                'gpu_available': GPU_AVAILABLE,
-                'timestamp': time.time()
-            })
-        
+            return jsonify(
+                {
+                    "status": "running",
+                    "service": self._svc_display_name_,
+                    "port": self.port,
+                    "gpu_available": True,
+                    "timestamp": time.time(),
+                }
+            )
+
         return app
 
     def get_default_data(self):
         """Return default performance data"""
         return {
-            'cpu': 0,
-            'memory': 0,
-            'gpu_usage': 0,
-            'vram_usage': 0,
-            'upload_speed': 0,
-            'download_speed': 0,
-            'timestamp': time.time()
+            "cpu": 0,
+            "memory": 0,
+            "gpu_usage": 0,
+            "vram_usage": 0,
+            "upload_speed": 0,
+            "download_speed": 0,
+            "timestamp": time.time(),
         }
 
     def get_performance_data(self):
         """Collect performance data"""
         try:
-            gpu_usage, vram_usage = 0, 0
-            if GPU_AVAILABLE:
-                try:
-                    gpus = GPUtil.getGPUs()
-                    if gpus:
-                        gpu = gpus[0]
-                        gpu_usage = round(gpu.load * 100, 1)
-                        vram_usage = round(gpu.memoryUsed / gpu.memoryTotal * 100, 1)
-                except Exception as e:
-                    logger.debug(f"GPU data unavailable: {e}")
+            gpu_usage = get_gpu_util()
+            vram_usage = get_gpu_vram()
 
             net_io_before = psutil.net_io_counters()
             time.sleep(1)
             net_io_after = psutil.net_io_counters()
-            
-            upload_speed = round((net_io_after.bytes_sent - net_io_before.bytes_sent) * 8 / 1000, 1)
-            download_speed = round((net_io_after.bytes_recv - net_io_before.bytes_recv) * 8 / 1000, 1)
+
+            upload_speed = round(
+                (net_io_after.bytes_sent - net_io_before.bytes_sent) * 8 / 1000, 1
+            )
+            download_speed = round(
+                (net_io_after.bytes_recv - net_io_before.bytes_recv) * 8 / 1000, 1
+            )
 
             data = {
-                'cpu': round(psutil.cpu_percent(), 1),
-                'memory': round(psutil.virtual_memory().percent, 1),
-                'gpu_usage': gpu_usage,
-                'vram_usage': vram_usage,
-                'upload_speed': upload_speed,
-                'download_speed': download_speed,
-                'timestamp': time.time()
+                "cpu": round(psutil.cpu_percent(), 1),
+                "memory": round(psutil.virtual_memory().percent, 1),
+                "gpu_usage": gpu_usage,
+                "vram_usage": vram_usage,
+                "upload_speed": upload_speed,
+                "download_speed": download_speed,
+                "timestamp": time.time(),
             }
 
             try:
                 for disk in psutil.disk_partitions():
-                    if 'cdrom' in disk.opts or disk.fstype == '':
+                    if "cdrom" in disk.opts or disk.fstype == "":
                         continue
                     try:
                         usage = psutil.disk_usage(disk.mountpoint)
                         drive_letter = disk.device[0].lower()
-                        data[f'{drive_letter}_disk'] = f"{usage.used / (1024**3):.1f} GB/{usage.total / (1024**3):.1f} GB"
+                        data[f"{drive_letter}_disk"] = (
+                            f"{usage.used / (1024**3):.1f} GB/{usage.total / (1024**3):.1f} GB"
+                        )
                     except PermissionError:
                         continue
                     except Exception:
@@ -214,7 +257,7 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
                 pass
 
             return data
-            
+
         except Exception as e:
             logger.error(f"Error getting performance data: {e}")
             return self.get_default_data()
@@ -222,22 +265,24 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
     def update_performance_loop(self):
         """Loop to update performance data"""
         logger.info("Performance monitoring started")
-        
+
         while self.running:
             try:
                 data = self.get_performance_data()
-                with open(self.data_file, 'w', encoding='utf-8') as f:
+                with open(self.data_file, "w", encoding="utf-8") as f:
                     json.dump(data, f, ensure_ascii=False, indent=2)
-                
+
                 self.performance_data = data
-                logger.debug(f"Performance data updated: CPU={data['cpu']}%, Memory={data['memory']}%")
-                
+                logger.debug(
+                    f"Performance data updated: CPU={data['cpu']}%, Memory={data['memory']}%"
+                )
+
             except Exception as e:
                 logger.error(f"Error updating performance data: {e}")
                 logger.error(traceback.format_exc())
-            
+
             time.sleep(1)
-        
+
         logger.info("Performance monitoring stopped")
 
     def run_flask(self):
@@ -245,11 +290,11 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
         try:
             logger.info(f"Starting Flask server on http://127.0.0.1:{self.port}")
             self.app.run(
-                host='127.0.0.1', 
-                port=self.port, 
+                host="127.0.0.1",
+                port=self.port,
                 debug=False,
                 use_reloader=False,
-                threaded=True
+                threaded=True,
             )
         except Exception as e:
             logger.error(f"Flask server error: {e}")
@@ -259,17 +304,19 @@ class PerformanceMonitorService(win32serviceutil.ServiceFramework):
         """Main processing"""
         try:
             self.app = self.create_flask_app()
-            self.monitor_thread = threading.Thread(target=self.update_performance_loop, daemon=True)
+            self.monitor_thread = threading.Thread(
+                target=self.update_performance_loop, daemon=True
+            )
             self.monitor_thread.start()
             logger.info("Performance monitoring thread started")
-            
+
             self.flask_thread = threading.Thread(target=self.run_flask, daemon=True)
             self.flask_thread.start()
             logger.info("Flask server thread started")
-            
+
             logger.info("Performance Monitor Service is running")
             win32event.WaitForSingleObject(self.hWaitStop, win32event.INFINITE)
-            
+
         except Exception as e:
             logger.error(f"Main thread error: {e}")
             logger.error(traceback.format_exc())
@@ -287,29 +334,29 @@ def request_admin_rights():
     """Request admin rights"""
     if check_admin_rights():
         return True
-    
+
     try:
         ctypes.windll.shell32.ShellExecuteW(
-            None, 
-            "runas", 
-            sys.executable, 
-            " ".join(sys.argv), 
-            None, 
-            1
+            None, "runas", sys.executable, " ".join(sys.argv), None, 1
         )
     except Exception as e:
         logger.error(f"Failed to request admin rights: {e}")
         return False
-    
+
     return False
+
 
 def install_service():
     """Install the Windows service"""
     try:
         logger.info("Installing Performance Monitor Service...")
-        exe_path = sys.executable if getattr(sys, 'frozen', False) else os.path.abspath(__file__)
+        exe_path = (
+            sys.executable
+            if getattr(sys, "frozen", False)
+            else os.path.abspath(__file__)
+        )
         logger.info(f"Service executable path: {exe_path}")
-        
+
         svc_name = PerformanceMonitorService._svc_name_
 
         try:
@@ -341,7 +388,9 @@ def install_service():
         except Exception as e:
             logger.debug(f"No existing service to remove or removal failed: {e}")
 
-        hscm = win32service.OpenSCManager(None, None, win32service.SC_MANAGER_ALL_ACCESS)
+        hscm = win32service.OpenSCManager(
+            None, None, win32service.SC_MANAGER_ALL_ACCESS
+        )
         try:
             service_cmd = f'"{exe_path}" debug'
             hs = win32service.CreateService(
@@ -357,18 +406,18 @@ def install_service():
                 0,
                 None,
                 None,
-                None
+                None,
             )
 
             try:
                 win32service.ChangeServiceConfig2(
                     hs,
                     win32service.SERVICE_CONFIG_DESCRIPTION,
-                    PerformanceMonitorService._svc_description_
+                    PerformanceMonitorService._svc_description_,
                 )
             except Exception as e:
                 logger.warning(f"Failed to set service description: {e}")
-            
+
             win32service.CloseServiceHandle(hs)
             logger.info("Service installed successfully")
             return True
@@ -386,9 +435,15 @@ def start_service():
     """Start the service"""
     try:
         logger.info("Starting Performance Monitor Service...")
-        hscm = win32service.OpenSCManager(None, None, win32service.SC_MANAGER_ALL_ACCESS)
+        hscm = win32service.OpenSCManager(
+            None, None, win32service.SC_MANAGER_ALL_ACCESS
+        )
         try:
-            hs = win32service.OpenService(hscm, PerformanceMonitorService._svc_name_, win32service.SERVICE_ALL_ACCESS)
+            hs = win32service.OpenService(
+                hscm,
+                PerformanceMonitorService._svc_name_,
+                win32service.SERVICE_ALL_ACCESS,
+            )
             try:
                 win32service.StartService(hs, None)
                 logger.info("Service started successfully")
@@ -397,7 +452,7 @@ def start_service():
                 win32service.CloseServiceHandle(hs)
         finally:
             win32service.CloseServiceHandle(hscm)
-            
+
     except Exception as e:
         logger.error(f"Service start failed: {e}")
         logger.error(traceback.format_exc())
@@ -406,15 +461,15 @@ def start_service():
 
 def get_service_port():
     try:
-        if getattr(sys, 'frozen', False):
+        if getattr(sys, "frozen", False):
             config_dir = Path(sys.executable).parent
         else:
             config_dir = Path(__file__).parent
 
-        config_file = config_dir / 'config.json'
+        config_file = config_dir / "config.json"
         if config_file.exists():
-            with open(config_file, 'r', encoding='utf-8') as f:
-                return json.load(f).get('port', 5000)
+            with open(config_file, "r", encoding="utf-8") as f:
+                return json.load(f).get("port", 5000)
         else:
             return 5000
     except Exception as e:
@@ -425,12 +480,12 @@ def get_service_port():
 def main():
     """Main function"""
     LOG_DIR.mkdir(exist_ok=True)
-    
-    if getattr(sys, 'frozen', False):
+
+    if getattr(sys, "frozen", False):
         if len(sys.argv) == 1:
             print("Performance Monitor Service Installer")
             print("====================================")
-            
+
             if not check_admin_rights():
                 print("Admin rights are required. Restarting as admin...")
                 if not request_admin_rights():
@@ -438,9 +493,9 @@ def main():
                     return
                 else:
                     return
-            
+
             print("Running with admin rights...")
-            
+
             if install_service():
                 print("Service installation completed.")
                 time.sleep(3)
@@ -454,35 +509,35 @@ def main():
                     print(f"Failed to start the service. Check logs at {LOG_FILE}")
             else:
                 print(f"Failed to install the service. Check logs at {LOG_FILE}")
-            
+
             input("\nPress Enter to exit...")
             return
         else:
             arg = sys.argv[1].lower()
-            
+
             if not check_admin_rights():
                 print("Admin rights are required.")
                 input("Press Enter to exit...")
                 return
-                
-            if arg == 'install':
+
+            if arg == "install":
                 if install_service():
                     print("Service installation completed.")
                     if start_service():
                         print("Service started successfully.")
                 return
-            elif arg == 'start':
+            elif arg == "start":
                 if start_service():
                     print("Service started successfully.")
                 return
-            elif arg == 'stop':
+            elif arg == "stop":
                 try:
                     win32serviceutil.StopService(PerformanceMonitorService._svc_name_)
                     print("Service stopped.")
                 except Exception as e:
                     print(f"Service stop error: {e}")
                 return
-            elif arg == 'remove':
+            elif arg == "remove":
                 try:
                     win32serviceutil.StopService(PerformanceMonitorService._svc_name_)
                     time.sleep(2)
@@ -494,7 +549,7 @@ def main():
                 except Exception as e:
                     print(f"Service removal error: {e}")
                 return
-            elif arg in ['debug', '--debug']:
+            elif arg in ["debug", "--debug"]:
                 logger.info("Running in debug mode")
                 servicemanager.Initialize()
                 servicemanager.PrepareToHostSingle(PerformanceMonitorService)
@@ -511,14 +566,14 @@ def main():
             win32serviceutil.HandleCommandLine(PerformanceMonitorService)
         else:
             print("Development mode - running service directly")
-            service = PerformanceMonitorService([''])
+            service = PerformanceMonitorService([""])
             service.main()
-    
+
     logger.info("Starting as Windows Service")
     servicemanager.Initialize()
     servicemanager.PrepareToHostSingle(PerformanceMonitorService)
     servicemanager.StartServiceCtrlDispatcher()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/performance_monitor_service.py
+++ b/performance_monitor_service.py
@@ -46,14 +46,14 @@ except ImportError:
             # Get adapter VRAM availability
             # Same concept as above for multi-GPU systems
             # Select highest VRAM GPU and use that
-            GPU_VRAM_AVAIL = run([
+            GPU_VRAM_AVAIL = int(run([
                 "powershell",
                 "-Command",
                 '(Get-WmiObject Win32_VideoController | Where-Object AdapterRam).AdapterRam | Measure-Object -Maximum | Select-Object -ExpandProperty Maximum'],
                     capture_output=True,
                     text=True,
                     check=True,
-            )
+            ).stdout or "0")
         except CalledProcessError:
             GPU_VRAM_AVAIL = 1 # Avoid division by zero
 

--- a/performance_monitor_service.py
+++ b/performance_monitor_service.py
@@ -32,11 +32,11 @@ try:
 
     def get_gpu_util():
         # Choose the GPU with the highest utilization (for multi-GPU systems, typically the primary GPU unless at very low load/weird usecases, which are less important)
-        return max(map(x.load for x in GPUtil.getGPUs()))
+        return max(x.load for x in GPUtil.getGPUs())
 
     def get_gpu_vram():
         # Choose the GPU with the highest total VRAM, and return that GPU's memory usage (same idea as above)
-        return (u/t for (u,t) in max(((x.memoryUsed, x.memoryTotal) for x in GPUtil.getGPUs()), key=lambda x: x[1]) if t>0).next()
+        return next((u/t for (u,t) in max(((x.memoryUsed, x.memoryTotal) for x in GPUtil.getGPUs()), key=lambda x: x[1]) if t>0), 0)
 
 except ImportError:
     if os.name == "nt":

--- a/performance_monitor_service.py
+++ b/performance_monitor_service.py
@@ -35,7 +35,7 @@ try:
 
     def get_gpu_vram():
         # Choose the GPU with the highest total VRAM, and return that GPU's memory usage (same idea as above)
-        return (u/t for (u,t) in max(((x.memoryUsed, x.memoryTotal) for x in GPUtil.getGPUs()), key=lambda x: x.memoryTotal) if t>0).next())
+        return (u/t for (u,t) in max(((x.memoryUsed, x.memoryTotal) for x in GPUtil.getGPUs()), key=lambda x: x.memoryTotal) if t>0).next()
 
 except ImportError:
     from subprocess import run, CalledProcessError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+blinker==1.9.0
+click==8.2.1
+colorama==0.4.6
+Flask==3.1.2
+flask-cors==6.0.1
+GPUtil==1.4.0
+itsdangerous==2.2.0
+Jinja2==3.1.6
+MarkupSafe==3.0.2
+psutil==7.0.0
+pywin32==311
+Werkzeug==3.1.3


### PR DESCRIPTION
Using Powershell perf counters, its possible to get a general GPU usage and VRAM total/usage for AMD GPU's, assuming Windows.

Also makes some small changes to extend support for multi-GPU systems (i.e. integrated & dedicated card) by assuming the higher-spec GPU is the GPU of interest, and modifies the build script to use a `requirements.txt` rather than a hard-coded list of packages, and places the `requirements.txt` in the root of the repo.

(I really like your wallpapers, but i have AMD hardware and would love to be able to use them :) )